### PR TITLE
androidのサムネイルサイズの最大値を1280pxに

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/Utility.kt
+++ b/android/src/main/kotlin/com/example/video_compress/Utility.kt
@@ -100,8 +100,8 @@ class Utility(private val channelName: String) {
         val width = bitmap!!.width
         val height = bitmap.height
         val max = Math.max(width, height)
-        if (max > 512) {
-            val scale = 512f / max
+        if (max > 1280) {
+            val scale = 1280f / max
             val w = Math.round(scale * width)
             val h = Math.round(scale * height)
             bitmap = Bitmap.createScaledBitmap(bitmap, w, h, true)


### PR DESCRIPTION
動画の最大が720x1280なのでサムネイルサイズもそれに合わせた