### PR TITLE
Fix ios compression

### DIFF
--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -209,7 +209,7 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
             exporter.timeRange = timeRange
         }
         
-        Utility.deleteFile(compressionUrl.absoluteString)
+        Utility.deleteFile(compressionUrl.absoluteString, clear: true)
         
         let timer = Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(self.updateProgress),
                                          userInfo: exporter, repeats: true)


### PR DESCRIPTION
同じファイルを複数回compressすると、2回目以降が圧縮行われず、1回目の結果が返っていた。
本来もとファイルを消す仕様なはずだが、そこがうまく動いてなかったので修正したら毎回compressが反映されるようになった。